### PR TITLE
many times faster using threads

### DIFF
--- a/sub_brute.rb
+++ b/sub_brute.rb
@@ -179,11 +179,11 @@ end
 puts "\n\n\n\n\n[#{Time.now.asctime}] Starting to bruteforce the subdomains using the same wordlist"
 File.open("output.txt", "r").each do |ff|
     ff.each_line do |domain|
-      targetURI = line.chomp + "." + domain.chomp
+      targetURI = domain.chomp
       unless fastmode then
-        createURI getURI
+        createURI targetURI
       else 
-        createURIThreaded getURI
+        createURIThreaded targetURI
       end
     end
 end


### PR DESCRIPTION
Thanks for this tool, it helped me very much. 
i want to payback by contributing to this tool.
here i used multiple threads for faster execution.
### how to run
use ``--fast`` argument option like,
```bash
ruby sub_brute.rb  --fast
```
### about threads
in line 144 i set threads as 100 for this PR. in real life i use much bigger value. which makes it much more faster. but for safe execution in smaller devices i set it to 100.

### issues
only issue is we can not guarantee ``seems like _ is an alias`` and related blocks comes in next line after url. so it is set that user need to explicitly specify ``--fast`` for this mode
